### PR TITLE
Initialize sails string arrays

### DIFF
--- a/src/logbook_pi.cpp
+++ b/src/logbook_pi.cpp
@@ -1290,7 +1290,10 @@ void logbookkonni_pi::LoadConfig()
 
             opt->abrSails.Empty();
             opt->sailsName.Empty();
-            
+
+            opt->abrSails.SetCount( opt->numberSails );
+            opt->sailsName.SetCount( opt->numberSails );
+
             for ( int i = 0; i < opt->numberSails; i++ )
             {
                 opt->abrSails.Item( i ) = tkz.GetNextToken();


### PR DESCRIPTION
This prevents a "access beyond size" warning that shows up when debug is enabled.  W/o debug,
the problem still exists but the log messag is suppressed.